### PR TITLE
added flags for resolving compilation issue for missing pthreads on a…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,8 @@ target_link_libraries(usgscsm
                       gtest ${CMAKE_THREAD_LIBS_INIT})
 
 if(WIN32)
+  option(CMAKE_USE_WIN32_THREADS_INIT "using WIN32 threads" ON)
+  option(gtest_disable_pthreads "Disable uses of pthreads in gtest." ON)
   install(TARGETS usgscsm
     RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
     install(DIRECTORY ${USGSCSM_INCLUDE_DIRS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})


### PR DESCRIPTION
Added modifications for resolving a compilation issue where pthreads weren't found (windows 10 machine with VS2017 Community Edition.)

On windows 10, this compiles but does not link. There are linking issues regarding __declspec(dllexport or dllimport).