### PR TITLE
UsgsAstroFramePlugin refactor, part one

### DIFF
--- a/include/usgscsm/UsgsAstroFramePlugin.h
+++ b/include/usgscsm/UsgsAstroFramePlugin.h
@@ -45,6 +45,8 @@ class UsgsAstroFramePlugin : public csm::Plugin {
     // TODO when implementing, add any other necessary members.
 
 private:
+    csm::Isd loadImageSupportData(const csm::Isd &imageSupportData) const; 
+
     static const UsgsAstroFramePlugin m_registeredPlugin;
     static const std::string _PLUGIN_NAME;
     static const std::string _MANUFACTURER_NAME;

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -781,8 +781,8 @@ void UsgsAstroFrameSensorModel::replaceModelState(const std::string& modelState)
         // Having types as vectors, instead of arrays makes interoperability with
         // the JSON library very easy.
         m_currentParameterValue = state["m_currentParameterValue"].get<std::vector<double>>();
-        m_odtX = state["m_odtX"].get<std::vector<double>>();
-        m_odtY = state["m_odtY"].get<std::vector<double>>();
+        m_odtX = state["odt_x"].get<std::vector<double>>();
+        m_odtY = state["odt_y"].get<std::vector<double>>();
 
         m_currentParameterCovariance = state["m_currentParameterCovariance"].get<std::vector<double>>();
     }

--- a/src/UsgsAstroFrameSensorModel.cpp
+++ b/src/UsgsAstroFrameSensorModel.cpp
@@ -781,8 +781,8 @@ void UsgsAstroFrameSensorModel::replaceModelState(const std::string& modelState)
         // Having types as vectors, instead of arrays makes interoperability with
         // the JSON library very easy.
         m_currentParameterValue = state["m_currentParameterValue"].get<std::vector<double>>();
-        m_odtX = state["odt_x"].get<std::vector<double>>();
-        m_odtY = state["odt_y"].get<std::vector<double>>();
+        m_odtX = state["m_odtX"].get<std::vector<double>>();
+        m_odtY = state["m_odtY"].get<std::vector<double>>();
 
         m_currentParameterCovariance = state["m_currentParameterCovariance"].get<std::vector<double>>();
     }

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -236,7 +236,6 @@ TEST_F(FrameIsdTest, Jacobian1) {
   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
-
   state["odt_x"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0};
   state["odt_y"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0};
   sensorModel->replaceModelState(state.dump()); 
@@ -257,44 +256,24 @@ TEST_F(FrameIsdTest, Jacobian1) {
 
 
 TEST_F(FrameIsdTest, distortMe_AllCoefficientsOne) {
+  csm::ImageCoord imagePt(7.5, 7.5);
 
-  int precision  = 20;
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state["odt_x"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  state["odt_y"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  sensorModel->replaceModelState(state.dump()); 
 
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
-
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
-
-   csm::ImageCoord imagePt(7.5, 7.5);
-
-   vector<double> odtx{1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
-   vector<double> odty{1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
-
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
-
-
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-   double dx,dy;
-   ASSERT_NE(sensorModel, nullptr);
-   sensorModel->distortionFunction(imagePt.samp, imagePt.line,dx,dy );
-
-   EXPECT_NEAR(dx,1872.25,1e-8 );
-   EXPECT_NEAR(dy,1872.25,1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
-
+  double dx,dy;
+  ASSERT_NE(sensorModel, nullptr);
+  sensorModel->distortionFunction(imagePt.samp, imagePt.line,dx,dy );
+  
+  EXPECT_NEAR(dx,1872.25,1e-8 );
+  EXPECT_NEAR(dy,1872.25,1e-8);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
 TEST_F(FrameIsdTest, setFocalPlane_AllCoefficientsOne) {

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -19,14 +19,13 @@ class FramerParameterizedTest : public ::testing::TestWithParam<csm::ImageCoord>
 protected:
   csm::Isd isd;
 
-
       void printIsd(csm::Isd &localIsd) {
            multimap<string,string> isdmap= localIsd.parameters();
            for (auto it = isdmap.begin(); it != isdmap.end();++it){
 
                       cout << it->first << " : " << it->second << endl;
            }
-       }
+      }
       UsgsAstroFrameSensorModel* createModel(csm::Isd &modifiedIsd) {
 
         UsgsAstroFramePlugin frameCameraPlugin;
@@ -39,16 +38,13 @@ protected:
           return sensorModel;
         else
           return nullptr;
-
-
       }
 
 
-
    virtual void SetUp() {
+     isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
 
-
-      std::ifstream isdFile("data/simpleFramerISD.json");
+/*      std::ifstream isdFile("data/simpleFramerISD.json");
       json jsonIsd = json::parse(isdFile);
       for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
          json jsonValue = it.value();
@@ -61,44 +57,36 @@ protected:
             isd.addParam(it.key(), jsonValue.dump());
          }
       }
-      isdFile.close();
-   }
+      isdFile.close();*/
+   };
 };
 
 
-
-
 class FrameIsdTest : public ::testing::Test {
-   protected:
-
-      csm::Isd isd;
-
-      void printIsd(csm::Isd &localIsd) {
-           multimap<string,string> isdmap= localIsd.parameters();
-           for (auto it = isdmap.begin(); it != isdmap.end();++it){
-
-                      cout << it->first << " : " << it->second << endl;
-           }
-       }
-      UsgsAstroFrameSensorModel* createModel(csm::Isd &modifiedIsd) {
-
-        UsgsAstroFramePlugin frameCameraPlugin;
-        csm::Model *model = frameCameraPlugin.constructModelFromISD(
+  protected:
+    csm::Isd isd;
+    void printIsd(csm::Isd &localIsd) {
+      multimap<string,string> isdmap= localIsd.parameters();
+      for (auto it = isdmap.begin(); it != isdmap.end();++it){
+        cout << it->first << " : " << it->second << endl;
+      }
+    }
+    UsgsAstroFrameSensorModel* createModel(csm::Isd &modifiedIsd) {
+      UsgsAstroFramePlugin frameCameraPlugin;
+      csm::Model *model = frameCameraPlugin.constructModelFromISD(
               modifiedIsd,"USGS_ASTRO_FRAME_SENSOR_MODEL");
-
-        UsgsAstroFrameSensorModel* sensorModel = dynamic_cast<UsgsAstroFrameSensorModel *>(model);
-
-        if (sensorModel)
-          return sensorModel;
-        else
-          return nullptr;
-
+      UsgsAstroFrameSensorModel* sensorModel = dynamic_cast<UsgsAstroFrameSensorModel *>(model);
+      if (sensorModel)
+        return sensorModel;
+      else
+        return nullptr;
       }
 
 
+    virtual void SetUp() {
+      isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
 
-   virtual void SetUp() {
-      std::ifstream isdFile("data/simpleFramerISD.json");
+/*      std::ifstream isdFile("data/simpleFramerISD.json");
       json jsonIsd = json::parse(isdFile);
       for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
          json jsonValue = it.value();
@@ -111,46 +99,25 @@ class FrameIsdTest : public ::testing::Test {
             isd.addParam(it.key(), jsonValue.dump());
          }
       }
-      isdFile.close();
+      isdFile.close();*/
    }
 };
 
 class FrameSensorModel : public ::testing::Test {
    protected:
-
-
       protected :
+      csm::Isd isd;
       UsgsAstroFrameSensorModel *sensorModel;
-
-
 
       void SetUp() override {
          sensorModel = NULL;
-         std::ifstream isdFile("data/simpleFramerISD.json");
-         json jsonIsd = json::parse(isdFile);
-         csm::Isd isd;
-         for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
-            json jsonValue = it.value();
-            if (jsonValue.size() > 1) {
-              for (int i = 0; i < jsonValue.size(); i++){
-                    isd.addParam(it.key(), jsonValue[i].dump());
-               }
-            }
-            else {
-               isd.addParam(it.key(), jsonValue.dump());
-            }
-         }
 
-         isdFile.close();
-
+         isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
          UsgsAstroFramePlugin frameCameraPlugin;
-
          csm::Model *model = frameCameraPlugin.constructModelFromISD(
                isd,
                "USGS_ASTRO_FRAME_SENSOR_MODEL");
-
          sensorModel = dynamic_cast<UsgsAstroFrameSensorModel *>(model);
-
          ASSERT_NE(sensorModel, nullptr);
       }
 
@@ -159,7 +126,6 @@ class FrameSensorModel : public ::testing::Test {
             delete sensorModel;
             sensorModel = NULL;
          }
-
       }
 };
 
@@ -170,53 +136,31 @@ INSTANTIATE_TEST_CASE_P(JacobianTest,FramerParameterizedTest,
 
 TEST_P(FramerParameterizedTest,JacobianTest) {
 
-  int precision  = 20;
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
-
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
-
-
-  vector<double> odtx{1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
-  vector<double> odty{0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
-
-
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
-
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   std::string modelState = sensorModel->getModelState(); 
+   auto state = json::parse(modelState);
 
+   state["odt_x"] = {1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0};
+   state["odt_y"] = {0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0};
+   sensorModel->replaceModelState(state.dump()); 
+   
    double Jxx,Jxy,Jyx,Jyy;
-
    ASSERT_NE(sensorModel, nullptr);
 
    csm::ImageCoord imagePt1 = GetParam();
    cout << "[" << imagePt1.samp << "," << imagePt1.line << "]"<< endl;
    sensorModel->distortionJacobian(imagePt1.samp, imagePt1.line, Jxx, Jxy,Jyx,Jyy);
 
-
    double determinant = fabs(Jxx*Jyy - Jxy*Jyx);
-
    EXPECT_GT(determinant,1e-3);
 
    delete sensorModel;
    sensorModel=NULL;
-
-
 }
 
-//NOTE: The imagePt format is (Lines,Samples)
+// NOTE: The imagePt format is (Lines,Samples)
 
-//centered and slightly off-center:
+// centered and slightly off-center:
 TEST_F(FrameSensorModel, Center) {
    csm::ImageCoord imagePt(7.5, 7.5);
    csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
@@ -232,7 +176,7 @@ TEST_F(FrameSensorModel, SlightlyOffCenter) {
    EXPECT_NEAR(groundPt.z, 1.98039612, 1e-8);
 }
 
-//Test all four corners:
+// Test all four corners:
 TEST_F(FrameSensorModel, OffBody1) {
    csm::ImageCoord imagePt(15.0, 0.0);
    csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
@@ -302,7 +246,6 @@ TEST_F(FrameIsdTest, setFocalPlane1) {
 }
 
 
-
 TEST_F(FrameIsdTest, Jacobian1) {
 
   int precision  = 20;
@@ -330,7 +273,6 @@ TEST_F(FrameIsdTest, Jacobian1) {
 
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
 
-
    double Jxx,Jxy,Jyx,Jyy;
 
    ASSERT_NE(sensorModel, nullptr);
@@ -343,7 +285,6 @@ TEST_F(FrameIsdTest, Jacobian1) {
 
    delete sensorModel;
    sensorModel = NULL;
-
 }
 
 
@@ -722,12 +663,11 @@ TEST_F(FrameIsdTest, Rotation_SPole_Center) {
 
 
 // Ellipsoid axis tests:
-TEST_F(FrameIsdTest, SemiMajorAxis100x_Center) {
+TEST_F(FrameIsdTest, SemiMajorAxis100x_Center) { //FIXME
    std::string key = "semi_major_axis";
    std::string newValue = "1.0";
    isd.clearParams(key);
    isd.addParam(key,newValue);
-
 
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
 
@@ -766,11 +706,13 @@ TEST_F(FrameIsdTest, SemiMajorAxis10x_SlightlyOffCenter) {
 // than the semi_major_axis:
 TEST_F(FrameIsdTest, SemiMinorAxis10x_SlightlyOffCenter) {
    std::string key = "semi_minor_axis";
-   std::string newValue = "0.10";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+   double newValue = 0.10;
 
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   std::string modelState = sensorModel->getModelState(); 
+   auto state = json::parse(modelState);
+   state[key] = newValue;
+   sensorModel->replaceModelState(state.dump()); 
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 6.5);
@@ -781,5 +723,4 @@ TEST_F(FrameIsdTest, SemiMinorAxis10x_SlightlyOffCenter) {
 
    delete sensorModel;
    sensorModel = NULL;
-
 }

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -277,131 +277,71 @@ TEST_F(FrameIsdTest, distortMe_AllCoefficientsOne) {
 }
 
 TEST_F(FrameIsdTest, setFocalPlane_AllCoefficientsOne) {
+  csm::ImageCoord imagePt(1872.25, 1872.25);
 
-  int precision  = 20;
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state["odt_x"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  state["odt_y"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  sensorModel->replaceModelState(state.dump()); 
 
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
+  double ux,uy;
+  ASSERT_NE(sensorModel, nullptr);
+  sensorModel->setFocalPlane(imagePt.samp, imagePt.line,ux,uy );
 
-   csm::ImageCoord imagePt(1872.25, 1872.25);
+  // The Jacobian is singular, so the setFocalPlane should break out of it's iteration and
+  // returns the same distorted coordinates that were passed in.
+  EXPECT_NEAR(ux,imagePt.samp,1e-8 );
+  EXPECT_NEAR(uy,imagePt.line,1e-8);
 
-   vector<double> odtx{1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
-   vector<double> odty{1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
-
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
-
-
-
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-
-   double ux,uy;
-   ASSERT_NE(sensorModel, nullptr);
-   sensorModel->setFocalPlane(imagePt.samp, imagePt.line,ux,uy );
-
-
-   //The Jacobian is singular, so the setFocalPlane should break out of it's iteration and
-   //returns the same distorted coordinates that were passed in.
-   EXPECT_NEAR(ux,imagePt.samp,1e-8 );
-   EXPECT_NEAR(uy,imagePt.line,1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
-
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
 
 TEST_F(FrameIsdTest, distortMe_AlternatingOnes) {
+  csm::ImageCoord imagePt(7.5, 7.5);
 
-  int precision  = 20;
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state["odt_x"] = {1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
+  state["odt_y"] = {0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
+  sensorModel->replaceModelState(state.dump()); 
 
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
-
-   csm::ImageCoord imagePt(7.5, 7.5);
-
-   vector<double> odtx{1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
-   vector<double> odty{0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
-
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
-
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-   double dx,dy;
-   ASSERT_NE(sensorModel, nullptr);
-   sensorModel->distortionFunction(imagePt.samp, imagePt.line,dx,dy );
-
-   EXPECT_NEAR(dx,908.5,1e-8 );
-   EXPECT_NEAR(dy,963.75,1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
-
+  double dx,dy;
+  ASSERT_NE(sensorModel, nullptr);
+  sensorModel->distortionFunction(imagePt.samp, imagePt.line,dx,dy );
+  
+  EXPECT_NEAR(dx,908.5,1e-8 );
+  EXPECT_NEAR(dy,963.75,1e-8);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
 
-
-
 TEST_F(FrameIsdTest, setFocalPlane_AlternatingOnes) {
+  csm::ImageCoord imagePt(963.75, 908.5);
 
-  int precision  = 20;
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state["odt_x"] = {1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
+  state["odt_y"] = {0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
+  sensorModel->replaceModelState(state.dump()); 
 
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
+  double ux,uy;
+  ASSERT_NE(sensorModel, nullptr);
 
-   csm::ImageCoord imagePt(963.75, 908.5);
+  sensorModel->setFocalPlane(imagePt.samp, imagePt.line,ux,uy );
 
-   vector<double> odtx{1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
-   vector<double> odty{0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
+  EXPECT_NEAR(ux,7.5,1e-8 );
+  EXPECT_NEAR(uy,7.5,1e-8);
 
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
-
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-   double ux,uy;
-   ASSERT_NE(sensorModel, nullptr);
-
-   sensorModel->setFocalPlane(imagePt.samp, imagePt.line,ux,uy );
-
-   EXPECT_NEAR(ux,7.5,1e-8 );
-   EXPECT_NEAR(uy,7.5,1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
-
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
 

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -42,7 +42,7 @@ protected:
 
 
    virtual void SetUp() {
-     isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
+     isd.setFilename("data/simpleFramerISD.json");
    };
 };
 
@@ -69,7 +69,7 @@ class FrameIsdTest : public ::testing::Test {
 
 
     virtual void SetUp() {
-      isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
+      isd.setFilename("data/simpleFramerISD.json");
    }
 };
 
@@ -82,7 +82,7 @@ class FrameSensorModel : public ::testing::Test {
       void SetUp() override {
          sensorModel = NULL;
 
-         isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
+         isd.setFilename("data/simpleFramerISD.json");
          UsgsAstroFramePlugin frameCameraPlugin;
          csm::Model *model = frameCameraPlugin.constructModelFromISD(
                isd,
@@ -98,8 +98,6 @@ class FrameSensorModel : public ::testing::Test {
          }
       }
 };
-
-
 
 INSTANTIATE_TEST_CASE_P(JacobianTest,FramerParameterizedTest,
                         ::testing::Values(csm::ImageCoord(2.5,2.5),csm::ImageCoord(7.5,7.5)));
@@ -408,7 +406,7 @@ TEST_F(FrameIsdTest, FL500_SlightlyOffCenter) {
 TEST_F(FrameIsdTest, X10_SlightlyOffCenter) {
    double newValue = 10.0;
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-   sensorModel->setParameterValue(0, newValue);
+   sensorModel->setParameterValue(0, newValue); // X
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 6.5);
@@ -426,7 +424,7 @@ TEST_F(FrameIsdTest, X1e9_SlightlyOffCenter) {
    double newValue = 1000000000.0;
 
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-   sensorModel->setParameterValue(0, newValue);
+   sensorModel->setParameterValue(0, newValue); // X
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 6.5);
@@ -444,7 +442,7 @@ TEST_F(FrameIsdTest, X1e9_SlightlyOffCenter) {
 // Angle rotations:
 TEST_F(FrameIsdTest, Rotation_omegaPi_Center) {
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-   sensorModel->setParameterValue(3, M_PI);
+   sensorModel->setParameterValue(3, M_PI); // omega
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 7.5);
@@ -459,25 +457,11 @@ TEST_F(FrameIsdTest, Rotation_omegaPi_Center) {
 
 
 TEST_F(FrameIsdTest, Rotation_NPole_Center) {
-   std::string key = "phi";
-   std::ostringstream strval;
-   strval << std::setprecision(20) << -M_PI;
-   isd.clearParams(key);
-   isd.addParam(key,strval.str());
-   key = "x_sensor_origin";
-   std::string newValue = "0.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-   key = "y_sensor_origin";
-   newValue = "0.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-   key = "z_sensor_origin";
-   newValue = "1000.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   sensorModel->setParameterValue(4, -M_PI); // phi
+   sensorModel->setParameterValue(0, 0.0); // X
+   sensorModel->setParameterValue(1, 0.0); // Y 
+   sensorModel->setParameterValue(2, 1000.0); // Z
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 7.5);
@@ -492,24 +476,11 @@ TEST_F(FrameIsdTest, Rotation_NPole_Center) {
 
 
 TEST_F(FrameIsdTest, Rotation_SPole_Center) {
-   std::string key = "phi";
-   std::string newValue = "0.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-   key = "x_sensor_origin";
-   newValue = "0.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-   key = "y_sensor_origin";
-   newValue = "0.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-   key = "z_sensor_origin";
-   newValue = "-1000.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   sensorModel->setParameterValue(4, 0.0); // phi
+   sensorModel->setParameterValue(0, 0.0); // X
+   sensorModel->setParameterValue(1, 0.0); // Y 
+   sensorModel->setParameterValue(2, -1000.0); // Z
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 7.5);

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -209,82 +209,50 @@ TEST_F(FrameSensorModel, OffBody4) {
 
 
 TEST_F(FrameIsdTest, setFocalPlane1) {
-  int precision  = 20;
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
-
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
-
   csm::ImageCoord imagePt(7.5, 7.5);
   double ux,uy;
 
-  vector<double> odtx{0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
-  vector<double> odty{0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
 
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
 
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
+  state["odt_x"] = {0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
+  state["odt_y"] = {0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
+  sensorModel->replaceModelState(state.dump()); 
 
-   UsgsAstroFrameSensorModel* sensorModel =createModel(isd);
-   ASSERT_NE(sensorModel, nullptr);
-   sensorModel->setFocalPlane(imagePt.samp, imagePt.line, ux, uy);
-   EXPECT_NEAR(imagePt.samp,7.5,1e-8 );
-   EXPECT_NEAR(imagePt.line,7.5,1e-8);   
-   delete sensorModel;
-   sensorModel = NULL;
-
-
+  ASSERT_NE(sensorModel, nullptr);
+  sensorModel->setFocalPlane(imagePt.samp, imagePt.line, ux, uy);
+  EXPECT_NEAR(imagePt.samp,7.5,1e-8 );
+  EXPECT_NEAR(imagePt.line,7.5,1e-8);   
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
 
 TEST_F(FrameIsdTest, Jacobian1) {
+  csm::ImageCoord imagePt(7.5, 7.5);
 
-  int precision  = 20;
-  std:string odtx_key= "odt_x";
-  std::string odty_key="odt_y";
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
 
-  isd.clearParams(odty_key);
-  isd.clearParams(odtx_key);
+  state["odt_x"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0};
+  state["odt_y"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0};
+  sensorModel->replaceModelState(state.dump()); 
 
-   csm::ImageCoord imagePt(7.5, 7.5);
+  double Jxx,Jxy,Jyx,Jyy;
 
-   vector<double> odtx{0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0};
-   vector<double> odty{0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0};
+  ASSERT_NE(sensorModel, nullptr);
+  sensorModel->distortionJacobian(imagePt.samp, imagePt.line, Jxx, Jxy,Jyx,Jyy);
 
-   for (auto & val: odtx){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_x", strval.str());
-   }
-   for (auto & val: odty){
-      ostringstream strval;
-      strval << setprecision(precision) << val;
-      isd.addParam("odt_y", strval.str());
-   }
-
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-   double Jxx,Jxy,Jyx,Jyy;
-
-   ASSERT_NE(sensorModel, nullptr);
-   sensorModel->distortionJacobian(imagePt.samp, imagePt.line, Jxx, Jxy,Jyx,Jyy);
-
-   EXPECT_NEAR(Jxx,56.25,1e-8 );
-   EXPECT_NEAR(Jxy,112.5,1e-8);
-   EXPECT_NEAR(Jyx,56.25,1e-8);
-   EXPECT_NEAR(Jyy,281.25,1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
+  EXPECT_NEAR(Jxx,56.25,1e-8 );
+  EXPECT_NEAR(Jxy,112.5,1e-8);
+  EXPECT_NEAR(Jyx,56.25,1e-8);
+  EXPECT_NEAR(Jyy,281.25,1e-8);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
 

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -43,21 +43,6 @@ protected:
 
    virtual void SetUp() {
      isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
-
-/*      std::ifstream isdFile("data/simpleFramerISD.json");
-      json jsonIsd = json::parse(isdFile);
-      for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
-         json jsonValue = it.value();
-         if (jsonValue.size() > 1) {
-            for (int i = 0; i < jsonValue.size(); i++) {
-               isd.addParam(it.key(), jsonValue[i].dump());
-            }
-         }
-         else {
-            isd.addParam(it.key(), jsonValue.dump());
-         }
-      }
-      isdFile.close();*/
    };
 };
 
@@ -85,21 +70,6 @@ class FrameIsdTest : public ::testing::Test {
 
     virtual void SetUp() {
       isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
-
-/*      std::ifstream isdFile("data/simpleFramerISD.json");
-      json jsonIsd = json::parse(isdFile);
-      for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
-         json jsonValue = it.value();
-         if (jsonValue.size() > 1) {
-            for (int i = 0; i < jsonValue.size(); i++) {
-               isd.addParam(it.key(), jsonValue[i].dump());
-            }
-         }
-         else {
-            isd.addParam(it.key(), jsonValue.dump());
-         }
-      }
-      isdFile.close();*/
    }
 };
 
@@ -140,8 +110,8 @@ TEST_P(FramerParameterizedTest,JacobianTest) {
    std::string modelState = sensorModel->getModelState(); 
    auto state = json::parse(modelState);
 
-   state["odt_x"] = {1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0};
-   state["odt_y"] = {0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0};
+   state["m_odtX"] = {1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0};
+   state["m_odtY"] = {0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0, 0.0, 1.0};
    sensorModel->replaceModelState(state.dump()); 
    
    double Jxx,Jxy,Jyx,Jyy;
@@ -217,8 +187,8 @@ TEST_F(FrameIsdTest, setFocalPlane1) {
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
 
-  state["odt_x"] = {0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
-  state["odt_y"] = {0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
+  state["m_odtX"] = {0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
+  state["m_odtY"] = {0.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0};
   sensorModel->replaceModelState(state.dump()); 
 
   ASSERT_NE(sensorModel, nullptr);
@@ -236,8 +206,8 @@ TEST_F(FrameIsdTest, Jacobian1) {
   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
-  state["odt_x"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0};
-  state["odt_y"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0};
+  state["m_odtX"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,0.0};
+  state["m_odtY"] = {0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0};
   sensorModel->replaceModelState(state.dump()); 
 
   double Jxx,Jxy,Jyx,Jyy;
@@ -261,8 +231,8 @@ TEST_F(FrameIsdTest, distortMe_AllCoefficientsOne) {
   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
-  state["odt_x"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
-  state["odt_y"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  state["m_odtX"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  state["m_odtY"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
   sensorModel->replaceModelState(state.dump()); 
 
   double dx,dy;
@@ -282,8 +252,8 @@ TEST_F(FrameIsdTest, setFocalPlane_AllCoefficientsOne) {
   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
-  state["odt_x"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
-  state["odt_y"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  state["m_odtX"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
+  state["m_odtY"] = {1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0};
   sensorModel->replaceModelState(state.dump()); 
 
   double ux,uy;
@@ -306,8 +276,8 @@ TEST_F(FrameIsdTest, distortMe_AlternatingOnes) {
   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
-  state["odt_x"] = {1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
-  state["odt_y"] = {0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
+  state["m_odtX"] = {1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
+  state["m_odtY"] = {0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
   sensorModel->replaceModelState(state.dump()); 
 
   double dx,dy;
@@ -328,8 +298,8 @@ TEST_F(FrameIsdTest, setFocalPlane_AlternatingOnes) {
   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
   std::string modelState = sensorModel->getModelState(); 
   auto state = json::parse(modelState);
-  state["odt_x"] = {1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
-  state["odt_y"] = {0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
+  state["m_odtX"] = {1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0};
+  state["m_odtY"] = {0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0,0.0,1.0};
   sensorModel->replaceModelState(state.dump()); 
 
   double ux,uy;
@@ -348,81 +318,93 @@ TEST_F(FrameIsdTest, setFocalPlane_AlternatingOnes) {
 
 // Focal Length Tests:
 TEST_F(FrameIsdTest, FL500_OffBody4) {
-   std::string key = "focal_length";
-   std::string newValue = "500.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+  std::string key = "m_focalLength";
+  double newValue = 500.0;
 
-
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(15.0, 15.0);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 9.77688917, 1e-8);
-   EXPECT_NEAR(groundPt.y, -1.48533467, 1e-8);
-   EXPECT_NEAR(groundPt.z, -1.48533467, 1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state[key] = newValue; 
+  sensorModel->replaceModelState(state.dump()); 
+  
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(15.0, 15.0);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  EXPECT_NEAR(groundPt.x, 9.77688917, 1e-8);
+  EXPECT_NEAR(groundPt.y, -1.48533467, 1e-8);
+  EXPECT_NEAR(groundPt.z, -1.48533467, 1e-8);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
+
+
 TEST_F(FrameIsdTest, FL500_OffBody3) {
-   std::string key = "focal_length";
-   std::string newValue = "500.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+  std::string key = "m_focalLength";
+  double newValue = 500.0;
 
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(0.0, 0.0);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 9.77688917, 1e-8);
-   EXPECT_NEAR(groundPt.y, 1.48533467, 1e-8);
-   EXPECT_NEAR(groundPt.z, 1.48533467, 1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state[key] = newValue; 
+  sensorModel->replaceModelState(state.dump()); 
+  
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(0.0, 0.0);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  EXPECT_NEAR(groundPt.x, 9.77688917, 1e-8);
+  EXPECT_NEAR(groundPt.y, 1.48533467, 1e-8);
+  EXPECT_NEAR(groundPt.z, 1.48533467, 1e-8);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
+
+
 TEST_F(FrameIsdTest, FL500_Center) {
-   std::string key = "focal_length";
-   std::string newValue = "500.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+  std::string key = "m_focalLength";
+  double newValue = 500.0;
 
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state[key] = newValue; 
+  sensorModel->replaceModelState(state.dump()); 
 
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 7.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
-
-   delete sensorModel;
-   sensorModel = NULL;
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  EXPECT_NEAR(groundPt.x, 10.0, 1e-8);
+  EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+  EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
+
+
 TEST_F(FrameIsdTest, FL500_SlightlyOffCenter) {
-   std::string key = "focal_length";
-   std::string newValue = "500.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+  std::string key = "m_focalLength";
+  double newValue = 500.0;
 
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state[key] = newValue; 
+  sensorModel->replaceModelState(state.dump()); 
 
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 6.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 9.99803960, 1e-8);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.z, 1.98000392e-01, 1e-8);
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(7.5, 6.5);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  EXPECT_NEAR(groundPt.x, 9.99803960, 1e-8);
+  EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+  EXPECT_NEAR(groundPt.z, 1.98000392e-01, 1e-8);
 
-   delete sensorModel;
-   sensorModel = NULL;
-
+  delete sensorModel;
+  sensorModel = NULL;
 }
 
-//Observer x position:
+// Observer x position:
 TEST_F(FrameIsdTest, X10_SlightlyOffCenter) {
    std::string key = "x_sensor_origin";
    std::string newValue = "10.0";
@@ -440,8 +422,9 @@ TEST_F(FrameIsdTest, X10_SlightlyOffCenter) {
 
    delete sensorModel;
    sensorModel = NULL;
-
 }
+
+
 TEST_F(FrameIsdTest, X1e9_SlightlyOffCenter) {
    std::string key = "x_sensor_origin";
    std::string newValue = "1000000000.0";
@@ -463,7 +446,7 @@ TEST_F(FrameIsdTest, X1e9_SlightlyOffCenter) {
 
 }
 
-//Angle rotations:
+// Angle rotations:
 TEST_F(FrameIsdTest, Rotation_omegaPi_Center) {
    std::string key = "omega";
    std::ostringstream strval;
@@ -482,8 +465,9 @@ TEST_F(FrameIsdTest, Rotation_omegaPi_Center) {
 
    delete sensorModel;
    sensorModel = NULL;
-
 }
+
+
 TEST_F(FrameIsdTest, Rotation_NPole_Center) {
    std::string key = "phi";
    std::ostringstream strval;
@@ -514,8 +498,9 @@ TEST_F(FrameIsdTest, Rotation_NPole_Center) {
 
    delete sensorModel;
    sensorModel = NULL;
-
 }
+
+
 TEST_F(FrameIsdTest, Rotation_SPole_Center) {
    std::string key = "phi";
    std::string newValue = "0.0";
@@ -545,55 +530,61 @@ TEST_F(FrameIsdTest, Rotation_SPole_Center) {
 
    delete sensorModel;
    sensorModel = NULL;
-
 }
 
 
 // Ellipsoid axis tests:
-TEST_F(FrameIsdTest, SemiMajorAxis100x_Center) { //FIXME
-   std::string key = "semi_major_axis";
-   std::string newValue = "1.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+TEST_F(FrameIsdTest, SemiMajorAxis100x_Center) {
+  std::string key = "m_majorAxis";
+  double newValue = 1000.0;
 
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state[key] = newValue; 
+  sensorModel->replaceModelState(state.dump()); 
 
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 7.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   EXPECT_NEAR(groundPt.x, 1000.0, 1e-8);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
-   EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(7.5, 7.5);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  EXPECT_NEAR(groundPt.x, 1000.0, 1e-8);
+  EXPECT_NEAR(groundPt.y, 0.0, 1e-8);
+  EXPECT_NEAR(groundPt.z, 0.0, 1e-8);
 
-   delete sensorModel;
-   sensorModel = NULL;
-
+  delete sensorModel;
+  sensorModel = NULL;
 }
+
+
 TEST_F(FrameIsdTest, SemiMajorAxis10x_SlightlyOffCenter) {
-   std::string key = "semi_major_axis";
-   std::string newValue = "0.10";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+  std::string key = "m_majorAxis";
+  double newValue = 100.0;
 
-   UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
-   ASSERT_NE(sensorModel, nullptr);
-   csm::ImageCoord imagePt(7.5, 6.5);
-   csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   //Note: In the following, the tolerance was increased due to the combination of an offset image point and
-   //      a very large deviation from sphericity.
-   EXPECT_NEAR(groundPt.x, 9.83606557e+01, 1e-7);
-   EXPECT_NEAR(groundPt.y, 0.0, 1e-7);
-   EXPECT_NEAR(groundPt.z, 1.80327869, 1e-7);
+  UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+  std::string modelState = sensorModel->getModelState(); 
+  auto state = json::parse(modelState);
+  state[key] = newValue; 
+  sensorModel->replaceModelState(state.dump()); 
 
-   delete sensorModel;
-   sensorModel = NULL;
-
+  ASSERT_NE(sensorModel, nullptr);
+  csm::ImageCoord imagePt(7.5, 6.5);
+  csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
+  // Note: In the following, the tolerance was increased due to the combination of an offset image point and
+  //       a very large deviation from sphericity.
+  EXPECT_NEAR(groundPt.x, 9.83606557e+01, 1e-7);
+  EXPECT_NEAR(groundPt.y, 0.0, 1e-7);
+  EXPECT_NEAR(groundPt.z, 1.80327869, 1e-7);
+  
+  delete sensorModel;
+  sensorModel = NULL;
 }
+
+
 // The following test is for the scenario where the semi_minor_axis is actually larger
 // than the semi_major_axis:
 TEST_F(FrameIsdTest, SemiMinorAxis10x_SlightlyOffCenter) {
-   std::string key = "semi_minor_axis";
-   double newValue = 0.10;
+   std::string key = "m_minorAxis";
+   double newValue = 100.0;
 
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
    std::string modelState = sensorModel->getModelState(); 

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -42,7 +42,7 @@ protected:
 
 
    virtual void SetUp() {
-     isd.setFilename("data/simpleFramerISD.json");
+     isd.setFilename("data/simpleFramerISD.img");
    };
 };
 
@@ -69,7 +69,7 @@ class FrameIsdTest : public ::testing::Test {
 
 
     virtual void SetUp() {
-      isd.setFilename("data/simpleFramerISD.json");
+      isd.setFilename("data/simpleFramerISD.img");
    }
 };
 
@@ -82,7 +82,7 @@ class FrameSensorModel : public ::testing::Test {
       void SetUp() override {
          sensorModel = NULL;
 
-         isd.setFilename("data/simpleFramerISD.json");
+         isd.setFilename("data/simpleFramerISD.img");
          UsgsAstroFramePlugin frameCameraPlugin;
          csm::Model *model = frameCameraPlugin.constructModelFromISD(
                isd,

--- a/tests/FrameCameraTests.cpp
+++ b/tests/FrameCameraTests.cpp
@@ -406,12 +406,9 @@ TEST_F(FrameIsdTest, FL500_SlightlyOffCenter) {
 
 // Observer x position:
 TEST_F(FrameIsdTest, X10_SlightlyOffCenter) {
-   std::string key = "x_sensor_origin";
-   std::string newValue = "10.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
-
+   double newValue = 10.0;
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   sensorModel->setParameterValue(0, newValue);
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 6.5);
@@ -426,35 +423,28 @@ TEST_F(FrameIsdTest, X10_SlightlyOffCenter) {
 
 
 TEST_F(FrameIsdTest, X1e9_SlightlyOffCenter) {
-   std::string key = "x_sensor_origin";
-   std::string newValue = "1000000000.0";
-   isd.clearParams(key);
-   isd.addParam(key,newValue);
+   double newValue = 1000000000.0;
 
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   sensorModel->setParameterValue(0, newValue);
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 6.5);
    csm::EcefCoord groundPt = sensorModel->imageToGround(imagePt, 0.0);
-   //Note: In the following, the tolerance was increased due to the very large distance being tested (~6.68 AU).
+   // Note: In the following, the tolerance was increased due to the very large distance being tested (~6.68 AU).
    EXPECT_NEAR(groundPt.x, 3.99998400e+03, 1e-4);
    EXPECT_NEAR(groundPt.y, 0.0, 1e-4);
    EXPECT_NEAR(groundPt.z, 1.99999200e+06, 1e-4);
 
    delete sensorModel;
    sensorModel = NULL;
-
 }
+
 
 // Angle rotations:
 TEST_F(FrameIsdTest, Rotation_omegaPi_Center) {
-   std::string key = "omega";
-   std::ostringstream strval;
-   strval << std::setprecision(20) << M_PI;
-   isd.clearParams(key);
-   isd.addParam(key,strval.str());
-
    UsgsAstroFrameSensorModel* sensorModel = createModel(isd);
+   sensorModel->setParameterValue(3, M_PI);
 
    ASSERT_NE(sensorModel, nullptr);
    csm::ImageCoord imagePt(7.5, 7.5);

--- a/tests/TestyMcTestFace.cpp
+++ b/tests/TestyMcTestFace.cpp
@@ -14,7 +14,7 @@ class FrameIsdTest : public ::testing::Test {
    protected:
      csm::Isd isd;
      virtual void SetUp() {
-       isd.setFilename("data/simpleFramerISD.json");
+       isd.setFilename("data/simpleFramerISD.img");
      };
 };
 

--- a/tests/TestyMcTestFace.cpp
+++ b/tests/TestyMcTestFace.cpp
@@ -14,7 +14,7 @@ class FrameIsdTest : public ::testing::Test {
    protected:
      csm::Isd isd;
      virtual void SetUp() {
-       isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
+       isd.setFilename("data/simpleFramerISD.json");
      };
 };
 

--- a/tests/TestyMcTestFace.cpp
+++ b/tests/TestyMcTestFace.cpp
@@ -12,25 +12,10 @@ using json = nlohmann::json;
 
 class FrameIsdTest : public ::testing::Test {
    protected:
-
-      csm::Isd isd;
-
-   virtual void SetUp() {
-      std::ifstream isdFile("data/simpleFramerISD.json");
-      json jsonIsd = json::parse(isdFile);
-      for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
-         json jsonValue = it.value();
-         if (jsonValue.size() > 1) {
-            for (int i = 0; i < jsonValue.size(); i++) {
-               isd.addParam(it.key(), jsonValue[i].dump());
-            }
-         }
-         else {
-            isd.addParam(it.key(), jsonValue.dump());
-         }
-      }
-      isdFile.close();
-   }
+     csm::Isd isd;
+     virtual void SetUp() {
+       isd.setFilename("/home/kberry/csm/CSM-CameraModel/tests/data/simpleFramerISD.json");
+     };
 };
 
 TEST(FramePluginTests, PluginName) {


### PR DESCRIPTION
This includes the updates to `UsgsAstroFramePlugin` to switch from expecting the SET to parse a json ISD into a `csm::Isd` object that will be passed to this plugin to expecting the SET to construct a `csm::Isd('image file name')` to pass to the plugin. Now the plugin parses the json isd. It looks for a json isd file named 'filename.json' next to the provided image filename. This should fix #110 

The existing tests needed to be updated for this change. 

Now, `canModelBeConstructedFromISD` works on both 'filename only' `csm::Isd` objects and ones that have already been populated with values from the json isd file. 

I added a helper function I called `csm::Isd loadImageSupportData(const csm::Isd&) const` which takes a 'filename only' `csm::Isd` and creates and returns a new Isd populated with values from the associated json isd file. Is this function-name confusing, or all-right as is? 