### PR TITLE
Fixed canModelBeConstructedFromISD throwing an exception when the metadata file doesn't exist.

### DIFF
--- a/src/UsgsAstroFramePlugin.cpp
+++ b/src/UsgsAstroFramePlugin.cpp
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
-#include <map> 
+#include <map>
 
 #include <math.h>
 #include <csm.h>
@@ -262,21 +262,21 @@ return sensor_model;
 
 // This function takes a csm::Isd which only has the image filename set. It uses this filename to
 // find a metadata json file loacated alongside the image file. It creates and returns new csm::Isd
-// with its parameters populated by the metadata file. 
+// with its parameters populated by the metadata file.
 csm::Isd UsgsAstroFramePlugin::loadImageSupportData(const csm::Isd &imageSupportDataOriginal) const{
-  // Get image location from the input csm::Isd: 
-  std::string imageFilename = imageSupportDataOriginal.filename(); 
-  
+  // Get image location from the input csm::Isd:
+  std::string imageFilename = imageSupportDataOriginal.filename();
+
   // Load 'sidecar' ISD file
-  size_t lastIndex = imageFilename.find_last_of("."); 
-  std::string baseName = imageFilename.substr(0, lastIndex); 
+  size_t lastIndex = imageFilename.find_last_of(".");
+  std::string baseName = imageFilename.substr(0, lastIndex);
   std::string isdFilename = baseName.append(".json");
 
   csm::Isd imageSupportData(isdFilename);
   imageSupportData.clearAllParams();
 
   try {
-    std::ifstream isdFile(isdFilename); 
+    std::ifstream isdFile(isdFilename);
     json jsonIsd = json::parse(isdFile);
 
     for (json::iterator it = jsonIsd.begin(); it != jsonIsd.end(); ++it) {
@@ -290,15 +290,15 @@ csm::Isd UsgsAstroFramePlugin::loadImageSupportData(const csm::Isd &imageSupport
         imageSupportData.addParam(it.key(), jsonValue.dump());
      }
   }
-    isdFile.close(); 
+    isdFile.close();
   } catch (...) {
     std::string errorMessage = "Could not read metadata file associated with image: ";
     errorMessage.append(isdFilename);
-    throw csm::Error(csm::Error::FILE_READ, errorMessage, 
-                     "UsgsAstroFramePlugin::loadImageSupportData"); 
+    throw csm::Error(csm::Error::FILE_READ, errorMessage,
+                     "UsgsAstroFramePlugin::loadImageSupportData");
   }
 
-  return imageSupportData; 
+  return imageSupportData;
 }
 
 csm::Model *UsgsAstroFramePlugin::constructModelFromISD(const csm::Isd &imageSupportDataOriginal,
@@ -317,18 +317,18 @@ csm::Model *UsgsAstroFramePlugin::constructModelFromISD(const csm::Isd &imageSup
      return val*pow(10, typemap[from].get<int>() - typemap[to].get<int>());
   };
 
-  csm::Isd imageSupportData = loadImageSupportData(imageSupportDataOriginal);
-
   // Check if the sensor model can be constructed from ISD given the model name
-  if (!canModelBeConstructedFromISD(imageSupportData, modelName)) {
+  if (!canModelBeConstructedFromISD(imageSupportDataOriginal, modelName)) {
     throw csm::Error(csm::Error::ISD_NOT_SUPPORTED,
                      "Sensor model support data provided is not supported by this plugin",
                      "UsgsAstroFramePlugin::constructModelFromISD");
   }
 
+  csm::Isd imageSupportData = loadImageSupportData(imageSupportDataOriginal);
+
   // Create the empty sensorModel
   UsgsAstroFrameSensorModel *sensorModel = new UsgsAstroFrameSensorModel();
-  
+
   // Keep track of necessary keywords that are missing from the ISD.
   std::vector<std::string> missingKeywords;
 
@@ -651,9 +651,12 @@ bool UsgsAstroFramePlugin::canISDBeConvertedToModelState(const csm::Isd &imageSu
       convertible = false;
   }
 
-  csm::Isd localImageSupportData = imageSupportData; 
-  if (imageSupportData.parameters().empty()) {
-    localImageSupportData = loadImageSupportData(imageSupportData); 
+  csm::Isd localImageSupportData;
+  try {
+    localImageSupportData = loadImageSupportData(imageSupportData);
+  }
+  catch (...) {
+     return false;
   }
 
   std::string value;

--- a/tests/FramePluginTests.cpp
+++ b/tests/FramePluginTests.cpp
@@ -70,6 +70,14 @@ TEST_F(SimpleFrameIsdTest, Constructible) {
                "USGS_ASTRO_FRAME_SENSOR_MODEL"));
 }
 
+TEST_F(SimpleFrameIsdTest, NotConstructible) {
+   UsgsAstroFramePlugin testPlugin;
+   isd.setFilename("Not a file");
+   EXPECT_FALSE(testPlugin.canModelBeConstructedFromISD(
+                isd,
+                "USGS_ASTRO_FRAME_SENSOR_MODEL"));
+}
+
 TEST_F(SimpleFrameIsdTest, ConstructValidCamera) {
    UsgsAstroFramePlugin testPlugin;
    csm::Model *cameraModel = NULL;


### PR DESCRIPTION
This should fix #133 it will need to be built on windows to test for sure first.